### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/homeassistant-bitvavo/__init__.py
+++ b/custom_components/homeassistant-bitvavo/__init__.py
@@ -10,10 +10,10 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Bitvavo from a config entry."""
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "sensor")
+        hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     )
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload Bitvavo config entry."""
-    return await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+    return await hass.config_entries.async_forward_entry_unload(entry, ["sensor"])


### PR DESCRIPTION
The Bitvavo custom component is using the deprecated Home Assistant API method async_forward_entry_setup. This method was removed in Home Assistant version 2023.3 and replaced with async_forward_entry_setups (note the 's' at the end).

Works on my instance of Home Assistant